### PR TITLE
updated app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,11 +1,28 @@
 runtime: nodejs
-env: flex
 
-# This sample incurs costs to run on the App Engine flexible environment.
-  # The settings below are to reduce costs during testing and are not appropriate
-# for production use. For more information, see:
-# https://cloud.google.com/appengine/docs/flexible/nodejs/configuring-your-app-with-app-yaml
-manual_scaling:
-  instances: 1
-resources:
-  cpu: 1
+handlers:
+  - url: /static/js/(.*)
+    static_files: build/static/js/\1
+    upload: build/static/js/(.*)
+  - url: /static/css/(.*)
+    static_files: build/static/css/\1
+    upload: build/static/css/(.*)
+  - url: /static/media/(.*)
+    static_files: build/static/media/\1
+    upload: build/static/media/(.*)
+  - url: /(.*\.(json|ico))$
+    static_files: build/\1
+    upload: build/.*\.(json|ico)$
+  - url: /
+    static_files: build/index.html
+    upload: build/index.html
+  - url: /.*
+    static_files: build/index.html
+    upload: build/index.html
+
+skip_files:
+- public
+- src
+- ^node_modules
+- package.json
+- package-lock.json


### PR DESCRIPTION
Removed flex from the env, I'm assuming this tutorial was written prior to app engine standard being available. The reason we want to use standard instead of flexible is because the flexible env requires having at least one instance up always. Standard can scale down to 0 so when the app is not getting any traffic you wont be billed for compute hours(up time for a vm to run the application). You shouldnt end up needing to really pay for any of this, you should be able to stay in the free tier.

The main thing that was missing before were handlers( routing handlers), so when a request came in before there was nothing to respond to a request. 
The routes below should make sure that all of the resource in the /build folder are accessible.

So the rules are done in order they appear, so if a more generic one comes before a more specific one then it will always go to that. So the last one here is /.* which means catch all because it will match any route, this should always be the last one(there are times where this might be used to catch if you go to an error page or something).

lastly I added a section called skip_files which will say dont upload any of these files/folders when deploying. This will reduce the upload time significantly because node_modules can get very large.